### PR TITLE
Fix for Breakpoint mounting; refactor SCSS library initialization

### DIFF
--- a/.storybook/decorators/globalStyles.scss
+++ b/.storybook/decorators/globalStyles.scss
@@ -1,0 +1,3 @@
+@import '../../src/index.scss';
+
+@include global-styles();

--- a/.storybook/decorators/globalStyles.ts
+++ b/.storybook/decorators/globalStyles.ts
@@ -1,3 +1,3 @@
-import '../../src/index.scss';
+import './globalStyles.scss';
 
 export const globalStyles = storyFn => storyFn();

--- a/src/components/Breakpoint/Breakpoint.tsx
+++ b/src/components/Breakpoint/Breakpoint.tsx
@@ -33,6 +33,7 @@ export const Breakpoint: React.FC<At | GreaterThan | LessThan> = ({ children, ..
   React.useEffect(() => {
     const mql = window.matchMedia(mediaQuery);
     mql.addListener(handleChange);
+    setMatches(mql.matches);
     return (): void => mql.removeListener(handleChange);
   }, [handleChange, mediaQuery]);
 

--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -9,7 +9,6 @@
   align-items: center;
   justify-content: center;
   text-align: center;
-  margin: 0;
   padding: spacing(4, 7);
   border: 1px solid;
   cursor: pointer;

--- a/src/components/Clickable/Clickable.scss
+++ b/src/components/Clickable/Clickable.scss
@@ -2,7 +2,6 @@
 
 .Clickable {
   appearance: none;
-  margin: 0;
   padding: 0;
   border: 0;
   background-color: transparent;

--- a/src/index.scss
+++ b/src/index.scss
@@ -2,10 +2,3 @@
 
 @import './mixins/mixins';
 @import './functions/functions';
-
-@include global-styles;
-
-body,
-input {
-  @include font-smoothing(antialiased);
-}

--- a/src/mixins/global-styles/_global-styles.scss
+++ b/src/mixins/global-styles/_global-styles.scss
@@ -1,4 +1,5 @@
 @import '~@moda/tokens';
+@import '../font-smoothing/font-smoothing';
 
 @mixin global-styles() {
   html {
@@ -27,6 +28,10 @@
     font-weight: normal;
   }
 
+  button {
+    margin: 0;
+  }
+
   ol,
   ul {
     list-style: none;
@@ -35,5 +40,10 @@
   img {
     max-width: 100%;
     height: auto;
+  }
+
+  body,
+  input {
+    @include font-smoothing(antialiased);
   }
 }


### PR DESCRIPTION
- removes global-styles invocation when importing library
- includes margin reset for buttons (Safari has a 2px margin on all buttons)
- fixes initial mount/unmount of Breakpoint