### PR TITLE
feat(input): add optional label to input

### DIFF
--- a/src/components/Input/Input.scss
+++ b/src/components/Input/Input.scss
@@ -3,26 +3,46 @@
 .Input {
   @include text(body1);
   line-height: 1;
-  padding: spacing(3, 4);
-  border: 1px solid color(elephant);
-  background-color: color(snow);
 
-  &--focus,
-  &:focus {
-    outline: none;
-    border-color: color(cement);
+  &__input {
+    padding: spacing(3, 4);
+    border: 1px solid color(elephant);
+    background-color: color(snow);
+
+    &--focus,
+    &:focus {
+      outline: none;
+      border-color: color(cement);
+    }
+
+    &--disabled,
+    &:disabled {
+      opacity: 0.75;
+    }
+
+    &--valid {
+      border-color: color(money-good);
+    }
+
+    &--error {
+      border-color: color(code-red);
+    }
   }
 
-  &--disabled,
-  &:disabled {
-    opacity: 0.75;
-  }
+  &__label {
+    &--error {
+      color: color(code-red);
+    }
 
-  &--valid {
-    border-color: color(money-good);
-  }
-
-  &--error {
-    border-color: color(code-red);
+    &--hidden {
+      border: 0;
+      clip: rect(0 0 0 0);
+      height: 1px;
+      margin: -1px;
+      overflow: hidden;
+      padding: 0;
+      position: absolute;
+      width: 1px;
+    }
   }
 }

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -13,7 +13,8 @@ export const Default = () => (
       { disabled: true },
       { defaultValue: 'With value' },
       { valid: true },
-      { error: true, defaultValue: 'With value' }
+      { error: 'Error', defaultValue: 'With value' },
+      { label: 'Label' }
     ]}
   >
     <Input placeholder='An input' />

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -6,8 +6,39 @@ import { Input } from './Input';
 describe('Input', () => {
   it('renders correctly', () => {
     const component = shallow(<Input placeholder='Placeholder' defaultValue='Hello' />);
+
     expect(component.html()).toEqual(
-      '<input class="Input" placeholder="Placeholder" value="Hello"/>'
+      '<label class="Input"><input class="Input__input" placeholder="Placeholder" value="Hello"/><span class="Input__label Input__label--hidden">Placeholder</span></label>'
+    );
+  });
+
+  it('renders with a label', () => {
+    const component = shallow(
+      <Input placeholder='Placeholder' defaultValue='Hello' label='Label' />
+    );
+
+    expect(component.html()).toEqual(
+      '<label class="Input"><input class="Input__input" placeholder="Placeholder" value="Hello"/><span class="Input__label">Label</span></label>'
+    );
+  });
+
+  it('renders with an error', () => {
+    const component = shallow(
+      <Input placeholder='Placeholder' defaultValue='Hello' label='Label' error='Error' />
+    );
+
+    expect(component.html()).toEqual(
+      '<label class="Input"><input class="Input__input Input__input--error" placeholder="Placeholder" value="Hello"/><span class="Input__label Input__label--error">Error</span></label>'
+    );
+  });
+
+  it('renders with a className', () => {
+    const component = shallow(
+      <Input className='Custom' placeholder='Placeholder' defaultValue='Hello' label='Label' />
+    );
+
+    expect(component.html()).toEqual(
+      '<label class="Input Custom"><input class="Input__input" placeholder="Placeholder" value="Hello"/><span class="Input__label">Label</span></label>'
     );
   });
 });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -4,27 +4,56 @@ import classNames from 'classnames';
 import './Input.scss';
 
 export interface Props extends React.InputHTMLAttributes<HTMLInputElement> {
-  focus?: boolean;
   disabled?: boolean;
+  error?: boolean | string;
+  focus?: boolean;
+  label?: string;
   valid?: boolean;
-  error?: boolean;
 }
 
-export const Input: React.FC<Props> = ({ className, focus, disabled, valid, error, ...rest }) => {
+export const Input: React.FC<Props> = ({
+  className,
+  disabled,
+  error,
+  focus,
+  label,
+  placeholder,
+  valid,
+  ...rest
+}) => {
   return (
-    <input
+    <label
       className={classNames(
         'Input',
-        {
-          'Input--focus': focus,
-          'Input--disabled': disabled,
-          'Input--valid': valid,
-          'Input--error': error
-        },
         className
       )}
-      disabled={disabled}
-      {...rest}
-    />
-  );
+    >
+      <input
+        className={classNames(
+          'Input__input',
+          {
+            'Input__input--focus': focus,
+            'Input__input--disabled': disabled,
+            'Input__input--valid': valid,
+            'Input__input--error': error
+          }
+        )}
+        disabled={disabled}
+        placeholder={placeholder}
+        {...rest}
+      />
+      <span
+        className={classNames(
+          'Input__label',
+          {
+            'Input__label--hidden': placeholder && !error && !label,
+            'Input__label--error': error
+          }
+        )}
+      >
+        {error || label || placeholder}
+      </span>
+    </label>
+  )
+
 };


### PR DESCRIPTION
This seemed like the easiest API to add here, but I am open to ideas on better setups. I basically don't want to have to manually wrap labels and inputs all over the app. 