### PR TITLE
chore: converts to using storybook-states

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "react-dom": "^16.11.0",
     "sass-loader": "^8.0.0",
     "semantic-release": "^17.0.1",
+    "storybook-states": "^1.0.2",
     "style-loader": "^1.0.0",
     "ts-jest": "^25.2.0",
     "typescript": "^3.7.2",

--- a/scripts/scaffold/react.js
+++ b/scripts/scaffold/react.js
@@ -32,7 +32,7 @@ export const ${componentName}: React.FC<Props> = ({ className, ...rest }) => (
 const STORIES = `
 import React from 'react';
 
-import { States } from '../../utilities/States';
+import { States } from 'storybook-states';
 import { ${componentName} } from './${componentName}';
 
 export default { title: '${componentType}|${componentName}' };

--- a/src/components/AspectRatioBox/AspectRatioBox.stories.tsx
+++ b/src/components/AspectRatioBox/AspectRatioBox.stories.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
+import { States } from 'storybook-states';
 
-import { States } from '../../utilities/States';
-import { AspectRatioBox } from './AspectRatioBox';
+import { AspectRatioBox, AspectRatioBoxProps } from './AspectRatioBox';
 
 export default { title: 'Components|AspectRatioBox' };
 
 export const Default = () => (
-  <States
+  <States<Partial<AspectRatioBoxProps>>
     states={[
       { aspectWidth: 3, aspectHeight: 4 },
       { aspectWidth: 4, aspectHeight: 3 },

--- a/src/components/Badge/Badge.stories.tsx
+++ b/src/components/Badge/Badge.stories.tsx
@@ -1,18 +1,20 @@
 import React from 'react';
+import { States } from 'storybook-states';
 
-import { Badge } from './Badge';
-import { States } from '../../utilities/States';
+import { Badge, BadgeProps } from './Badge';
 
 export default { title: 'Components|Badge' };
 
 export const Themes = () => (
-  <States states={[{ theme: 'bestseller' }, { theme: 'trending' }, { theme: 'fall-essential' }]}>
+  <States<BadgeProps>
+    states={[{ theme: 'bestseller' }, { theme: 'trending' }, { theme: 'fall-essential' }]}
+  >
     <Badge theme='bestseller' />
   </States>
 );
 
 export const CustomChildren = () => (
-  <States states={[{}]}>
+  <States<BadgeProps>>
     <Badge>Exclusive</Badge>
   </States>
 );

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
+import { States } from 'storybook-states';
 
-import { States } from '../../utilities/States';
-import { Breadcrumbs } from './Breadcrumbs';
+import { Breadcrumbs, BreadcrumbsProps } from './Breadcrumbs';
 
 export default { title: 'Components|Breadcrumbs' };
 
 export const Default = () => (
-  <States>
+  <States<BreadcrumbsProps>>
     <Breadcrumbs>
       <a href='#men'>Men</a>
       <a href='#clothing'>Clothing</a>

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,21 +1,21 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
+import { States } from 'storybook-states';
 
-import { States } from '../../utilities/States';
-import { Button } from './Button';
+import { Button, ButtonProps } from './Button';
 import { Stack } from '../Stack';
 import Heart from '@moda/icons/favorite-outline-16';
 
 export default { title: 'Components|Button' };
 
 export const Primary = () => (
-  <States states={[null, { hover: true }, { focus: true }, { disabled: true }]}>
+  <States<ButtonProps> states={[{}, { hover: true }, { focus: true }, { disabled: true }]}>
     <Button onClick={action('clicked')}>Add to Cart</Button>
   </States>
 );
 
 export const Secondary = () => (
-  <States states={[null, { hover: true }, { focus: true }, { disabled: true }]}>
+  <States<ButtonProps> states={[{}, { hover: true }, { focus: true }, { disabled: true }]}>
     <Button secondary onClick={action('clicked')}>
       Add to Cart
     </Button>
@@ -23,7 +23,7 @@ export const Secondary = () => (
 );
 
 export const PrimaryWithHref = () => (
-  <States states={[null, { hover: true }, { focus: true }, { disabled: true }]}>
+  <States<ButtonProps> states={[{}, { hover: true }, { focus: true }, { disabled: true }]}>
     <Button href='#href' onClick={action('clicked')}>
       Add to Cart
     </Button>
@@ -31,7 +31,7 @@ export const PrimaryWithHref = () => (
 );
 
 export const PrimaryWithIcon = () => (
-  <States states={[null, { hover: true }, { focus: true }, { disabled: true }]}>
+  <States<ButtonProps> states={[{}, { hover: true }, { focus: true }, { disabled: true }]}>
     <Button onClick={action('clicked')}>
       <Heart /> Add to Favorites
     </Button>
@@ -39,7 +39,7 @@ export const PrimaryWithIcon = () => (
 );
 
 export const SecondaryWithIcon = () => (
-  <States states={[null, { hover: true }, { focus: true }, { disabled: true }]}>
+  <States<ButtonProps> states={[{}, { hover: true }, { focus: true }, { disabled: true }]}>
     <Button secondary onClick={action('clicked')}>
       <Heart /> Add to Favorites
     </Button>

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,13 +1,13 @@
 import React, { useState } from 'react';
+import { States } from 'storybook-states';
 
-import { States } from '../../utilities/States';
 import { Text } from '../Text';
-import { Checkbox } from './Checkbox';
+import { Checkbox, CheckboxProps } from './Checkbox';
 
 export default { title: 'Components|Checkbox' };
 
 export const Default = () => (
-  <States
+  <States<CheckboxProps>
     states={[
       {},
       { checked: true },

--- a/src/components/Clickable/Clickable.stories.tsx
+++ b/src/components/Clickable/Clickable.stories.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-
-import { States } from '../../utilities/States';
-import { Clickable } from './Clickable';
+import { States } from 'storybook-states';
+import { Clickable, ClickableProps } from './Clickable';
 
 export default { title: 'Components|Clickable' };
 
 export const Default = () => (
-  <States>
+  <States<ClickableProps>>
     <Clickable onClick={action('onClick')}>
       Useful to extend in place of &lt;button&gt;. Click me.
     </Clickable>

--- a/src/components/ColorSwatch/ColorSwatch.stories.tsx
+++ b/src/components/ColorSwatch/ColorSwatch.stories.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-
-import { States } from '../../utilities/States';
+import { States } from 'storybook-states';
 import { Stack } from '../Stack';
-import { ColorSwatch } from './ColorSwatch';
+import { ColorSwatch, ColorSwatchProps } from './ColorSwatch';
 
 export default { title: 'Components|ColorSwatch' };
 
 const STATES = [
-  null,
+  {},
   { hover: true },
   { focus: true },
   { selected: true },
@@ -20,25 +19,25 @@ const STATES = [
 ];
 
 export const Default = () => (
-  <States states={STATES}>
+  <States<Partial<ColorSwatchProps>> states={STATES}>
     <ColorSwatch color='yellow' onClick={action('onClick')} />
   </States>
 );
 
 export const Small = () => (
-  <States states={STATES}>
+  <States<Partial<ColorSwatchProps>> states={STATES}>
     <ColorSwatch size='small' color='yellow' onClick={action('onClick')} />
   </States>
 );
 
 export const White = () => (
-  <States states={STATES}>
+  <States<Partial<ColorSwatchProps>> states={STATES}>
     <ColorSwatch size='small' color='white' onClick={action('onClick')} />
   </States>
 );
 
 export const Swatches = () => (
-  <States>
+  <States<ColorSwatchProps>>
     <Stack space={1} direction='horizontal'>
       <ColorSwatch onClick={action('onClick')} color='red' />
       <ColorSwatch onClick={action('onClick')} color='white' />

--- a/src/components/DefinitionList/DefinitionList.stories.tsx
+++ b/src/components/DefinitionList/DefinitionList.stories.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-
-import { States } from '../../utilities/States';
-import { DefinitionList } from './DefinitionList';
+import { States } from 'storybook-states';
+import { DefinitionList, DefinitionListProps } from './DefinitionList';
 import { Text } from '../Text';
 
 export default { title: 'Components|DefinitionList' };
 
 export const Default = () => (
-  <States
+  <States<DefinitionListProps>
     states={[
       { term: 'Color', children: 'Black' },
       { term: 'Size', children: 'Please select a size' },

--- a/src/components/Divider/Divider.stories.tsx
+++ b/src/components/Divider/Divider.stories.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
-
-import { States } from '../../utilities/States';
+import { States } from 'storybook-states';
 import { Divider, NoLineDivider, TwoLineDivider } from './';
+import { DividerProps } from './Divider';
 
 export default { title: 'Components|Divider' };
 
 export const Default = () => (
-  <States states={[{}, { type: 'no-line' }, { type: 'two-line' }]}>
+  <States<Partial<DividerProps>> states={[{}, { type: 'no-line' }, { type: 'two-line' }]}>
     <Divider text='Moda Operandi' />
   </States>
 );
 
-export const withNoLine = () => <NoLineDivider text='Divider with No Line' />;
+export const WithNoLine = () => <NoLineDivider text='Divider with No Line' />;
 
-export const withDoubleLine = () => <TwoLineDivider text='Divider with Double Line' />;
+export const WithDoubleLine = () => <TwoLineDivider text='Divider with Double Line' />;

--- a/src/components/Expandable/Expandable.stories.tsx
+++ b/src/components/Expandable/Expandable.stories.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
-
-import { States } from '../../utilities/States';
+import { States } from 'storybook-states';
 import { Stack } from '../Stack';
-import { Expandable } from './Expandable';
+import { Expandable, ExpandableProps } from './Expandable';
 
 export default { title: 'Components|Expandable' };
 
 export const Default = () => (
-  <States states={[null, { expanded: true }]}>
+  <States<Partial<ExpandableProps>> states={[{}, { expanded: true }]}>
     <Expandable name='Editor’s Note'>
       Mark Cross’ ‘Cole’ duffle bag is crafted from textured grain leather with ample space for your
       long-haul travels. It opens to reveal red twill lining and ample compartments for your

--- a/src/components/Field/Field.stories.tsx
+++ b/src/components/Field/Field.stories.tsx
@@ -1,15 +1,14 @@
 import React from 'react';
-
-import { States } from '../../utilities/States';
-import { Field } from './Field';
+import { States } from 'storybook-states';
+import { Field, FieldProps } from './Field';
 import { Textarea } from '../Textarea';
 
 export default { title: 'Components|Field' };
 
 export const Default = () => (
-  <States
+  <States<FieldProps>
     states={[
-      null,
+      {},
       { focus: true },
       { disabled: true },
       { defaultValue: 'With value' },
@@ -23,9 +22,9 @@ export const Default = () => (
 );
 
 export const AribitraryChildren = () => (
-  <States
+  <States<FieldProps>
     states={[
-      null,
+      {},
       { focus: true },
       { disabled: true },
       { defaultValue: 'With value' },

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-
-import { States } from '../../utilities/States';
-import { Label } from './Label';
+import { States } from 'storybook-states';
+import { Label, LabelProps } from './Label';
 
 export default { title: 'Components|Label' };
 
 export const Default = () => (
-  <States states={[{}, { hidden: true }]}>
+  <States<LabelProps> states={[{}, { hidden: true }]}>
     <Label>A label describes an input</Label>
   </States>
 );

--- a/src/components/Loading/Loading.stories.tsx
+++ b/src/components/Loading/Loading.stories.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-
-import { States } from '../../utilities/States';
-import { Loading } from './Loading';
+import { States } from 'storybook-states';
+import { Loading, LoadingProps } from './Loading';
 
 export default { title: 'Components|Loading' };
 
 export const Default = () => (
-  <States states={[{ speed: 100 }, { speed: 250 }, { speed: 500 }]}>
+  <States<LoadingProps> states={[{ speed: 100 }, { speed: 250 }, { speed: 500 }]}>
     <Loading />
   </States>
 );

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
-
-import { States } from '../../utilities/States';
+import { States } from 'storybook-states';
 import { Text } from '../Text';
-import { Popover } from './Popover';
+import { Popover, PopoverProps } from './Popover';
 
 export default { title: 'Components|Popover' };
 
@@ -16,7 +15,7 @@ const Content = (
 );
 
 export const Default = () => (
-  <States states={[null, { anchor: 'right' }, { open: true }]}>
+  <States<Partial<PopoverProps>> states={[{}, { anchor: 'right' }, { open: true }]}>
     <Popover content={Content}>
       <Text>Hover over me</Text>
     </Popover>

--- a/src/components/PromoBanner/PromoBanner.stories.tsx
+++ b/src/components/PromoBanner/PromoBanner.stories.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
-
-import { States } from '../../utilities/States';
-import { PromoBanner } from './PromoBanner';
+import { States } from 'storybook-states';
+import { PromoBanner, PromoBannerProps } from './PromoBanner';
 
 export default { title: 'Components|PromoBanner' };
 
 export const Default = () => (
-  <States
+  <States<PromoBannerProps>
     states={[
       { children: <span>Center</span> },
       {
@@ -35,7 +34,7 @@ export const Default = () => (
 );
 
 export const Mobile = () => (
-  <States>
+  <States<PromoBannerProps>>
     <PromoBanner>
       <span>Currency: USA (USD $)</span>
       <span>

--- a/src/components/RadioButton/RadioButton.stories.tsx
+++ b/src/components/RadioButton/RadioButton.stories.tsx
@@ -1,13 +1,12 @@
 import React, { useState } from 'react';
-
-import { States } from '../../utilities/States';
+import { States } from 'storybook-states';
 import { Text } from '../Text';
-import { RadioButton } from './RadioButton';
+import { RadioButton, RadioButtonProps } from './RadioButton';
 
 export default { title: 'Components|RadioButton' };
 
 export const Default = () => (
-  <States
+  <States<RadioButtonProps>
     states={[
       {},
       { checked: true },

--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -1,14 +1,13 @@
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
-
-import { States } from '../../utilities/States';
+import { States } from 'storybook-states';
 import { Text } from '../Text';
-import { SearchInput } from './SearchInput';
+import { SearchInput, SearchInputProps } from './SearchInput';
 
 export default { title: 'Components|SearchInput' };
 
 export const Default = () => (
-  <States states={[null, { value: 'prada' }, { autoFocus: true }]}>
+  <States<SearchInputProps> states={[{}, { value: 'prada' }, { autoFocus: true }]}>
     <SearchInput
       placeholder='Search'
       onChange={action('onChange')}

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
-import { States } from '../../utilities/States';
-import { Select } from './Select';
+import { States } from 'storybook-states';
+import { Select, SelectProps } from './Select';
 
 export default { title: 'Components|Select' };
 
@@ -22,7 +22,7 @@ const OPTIONS = [
 ];
 
 export const Default = () => (
-  <States
+  <States<Partial<SelectProps>>
     states={[{ idRef: '1' }, { idRef: '2', value: 'high' }, { idRef: '3', label: 'Sort — ' }]}
   >
     <Select label='Sort by:' options={OPTIONS} onChange={action('onChange')} />

--- a/src/components/SelectableButton/SelectableButton.stories.tsx
+++ b/src/components/SelectableButton/SelectableButton.stories.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
 
-import { States } from '../../utilities/States';
-import { SelectableButton } from './SelectableButton';
+import { States } from 'storybook-states';
+import { SelectableButton, SelectableButtonProps } from './SelectableButton';
 import { Stack } from '../Stack';
 
 export default { title: 'Components|SelectableButton' };
 
 export const Default = () => (
-  <States states={[null, { hover: true }, { selected: true }, { unavailable: true }]}>
+  <States<SelectableButtonProps>
+    states={[{}, { hover: true }, { selected: true }, { unavailable: true }]}
+  >
     <SelectableButton onClick={action('clicked')}>US 30</SelectableButton>
   </States>
 );

--- a/src/components/Stack/Stack.stories.tsx
+++ b/src/components/Stack/Stack.stories.tsx
@@ -1,13 +1,12 @@
 import React from 'react';
+import { States } from 'storybook-states';
 import { space } from '@moda/tokens';
-
-import { Stack } from './Stack';
-import { States } from '../../utilities/States';
+import { Stack, StackProps } from './Stack';
 
 export default { title: 'Components|Stack' };
 
 export const Vertical = () => (
-  <States states={space.scale.map((_, i) => ({ space: i, direction: 'vertical' }))}>
+  <States<StackProps> states={space.scale.map((_, i) => ({ space: i, direction: 'vertical' }))}>
     <Stack space={0}>
       <div style={{ backgroundColor: 'yellow' }}>One</div>
       <div style={{ backgroundColor: 'yellow' }}>Two</div>
@@ -17,7 +16,7 @@ export const Vertical = () => (
 );
 
 export const Horizontal = () => (
-  <States states={space.scale.map((_, i) => ({ space: i, direction: 'horizontal' }))}>
+  <States<StackProps> states={space.scale.map((_, i) => ({ space: i, direction: 'horizontal' }))}>
     <Stack space={0}>
       <div style={{ backgroundColor: 'yellow' }}>One</div>
       <div style={{ backgroundColor: 'yellow' }}>Two</div>

--- a/src/components/Tabs/Tab.scss
+++ b/src/components/Tabs/Tab.scss
@@ -7,6 +7,7 @@
   border-bottom: 2px solid transparent;
   color: color(cement);
   text-align: left;
+  cursor: pointer;
 
   &--active {
     color: color(ink);

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -1,20 +1,25 @@
 import React from 'react';
-
-import { Tabs } from './Tabs';
+import { States } from 'storybook-states';
+import { Text } from '../Text';
+import { Tabs, TabsProps } from './Tabs';
 
 export default { title: 'Components|Tabs' };
 
-const tabList = [
+const TAB_LIST = [
   {
     name: 'tab1',
     title: 'Tab 1',
-    panel: <div className='test'>I am a panel</div>
+    panel: <Text>First panel</Text>
   },
   {
     name: 'tab2',
     title: 'Tab 2',
-    panel: <div className='test'>I am also a panel</div>
+    panel: <Text>SecondPanel</Text>
   }
 ];
 
-export const Basic = () => <Tabs tabs={tabList} />;
+export const Basic = () => (
+  <States<TabsProps>>
+    <Tabs tabs={TAB_LIST} />
+  </States>
+);

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -1,25 +1,34 @@
 import React from 'react';
 import { typography, colors } from '@moda/tokens';
-
-import { States } from '../../utilities/States';
-import { Text } from './Text';
+import { States } from 'storybook-states';
+import { Text, TextProps, TextTreatment, TextColor, TextFontFamily } from './Text';
 
 export default { title: 'Components|Text' };
 
+const TREATMENTS = Object.keys(typography['text-treatments']).map(treatment => ({
+  treatment
+})) as { treatment: TextTreatment }[];
+
+const COLORS = Object.keys(colors.all).map(color => ({ color })) as { color: TextColor }[];
+
+const FAMILIES = Object.keys(typography.fonts).map(family => ({ family })) as {
+  family: TextFontFamily;
+}[];
+
 export const Treatments = () => (
-  <States states={Object.keys(typography['text-treatments']).map(treatment => ({ treatment }))}>
+  <States<TextProps> states={TREATMENTS}>
     <Text>Moda Operandi</Text>
   </States>
 );
 
 export const Colors = () => (
-  <States states={Object.keys(colors.all).map(color => ({ color }))}>
+  <States<Partial<TextProps>> states={COLORS}>
     <Text treatment='h5'>Moda Operandi</Text>
   </States>
 );
 
 export const Families = () => (
-  <States states={Object.keys(typography.fonts).map(family => ({ family }))}>
+  <States<Partial<TextProps>> states={FAMILIES}>
     <Text treatment='h5'>Moda Operandi</Text>
   </States>
 );

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -3,10 +3,14 @@ import classNames from 'classnames';
 import { typography, colors } from '@moda/tokens';
 import './Text.scss';
 
+export type TextTreatment = keyof typeof typography['text-treatments'];
+export type TextColor = keyof typeof colors.all;
+export type TextFontFamily = keyof typeof typography.fonts;
+
 export type TextProps = React.HTMLAttributes<HTMLSpanElement> & {
-  treatment?: keyof typeof typography['text-treatments'];
-  color?: keyof typeof colors.all;
-  family?: keyof typeof typography.fonts;
+  treatment?: TextTreatment;
+  color?: TextColor;
+  family?: TextFontFamily;
 };
 
 export const Text: React.FC<TextProps> = ({

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -1,14 +1,13 @@
 import React from 'react';
-
-import { States } from '../../utilities/States';
-import { TextInput } from './TextInput';
+import { States } from 'storybook-states';
+import { TextInput, TextInputProps } from './TextInput';
 
 export default { title: 'Components|TextInput' };
 
 export const Default = () => (
-  <States
+  <States<TextInputProps>
     states={[
-      null,
+      {},
       { focus: true },
       { disabled: true },
       { defaultValue: 'With value' },

--- a/src/components/Textarea/Textarea.stories.tsx
+++ b/src/components/Textarea/Textarea.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-
-import { States } from '../../utilities/States';
-import { Textarea } from './Textarea';
+import { States } from 'storybook-states';
+import { Textarea, TextareaProps } from './Textarea';
 
 export default { title: 'Components|Textarea' };
 
@@ -9,9 +8,9 @@ const MULTI_LINE_TEXT_EXAMPLE =
   'Lorem ipsum dolor sit, amet consectetur adipisicing elit. Temporibus iusto neque quidem dolor optio dignissimos, perspiciatis cumque voluptates! Maxime fugit at similique nemo illum tenetur excepturi maiores consequuntur eveniet quidem.';
 
 export const Default = () => (
-  <States
+  <States<TextareaProps>
     states={[
-      null,
+      {},
       { focus: true },
       { disabled: true },
       { defaultValue: 'With value' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12971,6 +12971,11 @@ storybook-chromatic@^2.2.2:
     tree-kill "^1.1.0"
     uuid "^3.3.2"
 
+storybook-states@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/storybook-states/-/storybook-states-1.0.2.tgz#a1387840fc87222dc281fdf97867315a7de86511"
+  integrity sha512-k4Rvra7/MlRwaYI/OUcFKFHdxNgObdvEtDDTmQ3hPeLxgjEtDvPPcwkgHWQVRj64x8wAHpqjwjYQe8sFvP/KKA==
+
 stream-browserify@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/stream-browserify/-/stream-browserify-2.0.2.tgz#87521d38a44aa7ee91ce1cd2a47df0cb49dd660b"


### PR DESCRIPTION
I wound up extracting the states component into it's [own package](https://github.com/dzucconi/storybook-states) — fixed some bugs and made it typesafe. This converts the stories to use it. I'll convert the stories in discovery then kill it in this package.