### PR TITLE
fix(checkbox): checked/defaultChecked behavior

### DIFF
--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -1,20 +1,39 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { Checkbox } from './Checkbox';
 
 describe('Checkbox', () => {
-  it('renders correctly', () => {
-    const component = mount(<Checkbox />);
-    expect(component.html()).toEqual(
-      '<label class="Checkbox"><span class="Checkbox__indicator"></span><input class="Checkbox__input" type="checkbox" value=""></label>'
+  it('works correctly with checked attribute (controlled)', () => {
+    const handleChange = jest.fn();
+    const { getByRole, getByTestId, rerender } = render(
+      <Checkbox data-testid='checkbox' checked onChange={handleChange} />
     );
+
+    expect((getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
+
+    userEvent.click(getByTestId('checkbox'));
+
+    expect(handleChange).toBeCalled();
+    expect((getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
+
+    rerender(<Checkbox data-testid='checkbox' checked={false} onChange={handleChange} />);
+
+    expect((getByRole('checkbox') as HTMLInputElement).checked).toBe(false);
   });
 
-  it('supports checked', () => {
-    const component = mount(<Checkbox checked readOnly />);
-    const html = component.html();
-    expect(html).toContain('<label class="Checkbox Checkbox--checked">');
-    expect(html).toContain('type="checkbox" readonly="" value="" checked=""');
+  it('works correctly with defaultChecked attribute (uncontrolled)', () => {
+    const handleChange = jest.fn();
+    const { getByRole, getByTestId } = render(
+      <Checkbox data-testid='checkbox' defaultChecked={false} onChange={handleChange} />
+    );
+
+    expect((getByRole('checkbox') as HTMLInputElement).checked).toBe(false);
+
+    userEvent.click(getByTestId('checkbox'));
+
+    expect(handleChange).toBeCalled();
+    expect((getByRole('checkbox') as HTMLInputElement).checked).toBe(true);
   });
 });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import classNames from 'classnames';
 import CheckboxCheckedIcon from '@moda/icons/checkbox-checked-12';
 import CheckboxUncheckedIcon from '@moda/icons/checkbox-unchecked-12';
@@ -17,20 +17,24 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   onChange,
   ...rest
 }) => {
-  const [isChecked, setIsChecked] = useState(defaultChecked || checked);
+  const [isChecked, setIsChecked] = useState(checked ?? defaultChecked ?? false);
+
+  useEffect(() => {
+    if (typeof checked !== 'undefined') setIsChecked(checked);
+  }, [checked]);
 
   const handleChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      setIsChecked(event.currentTarget.checked);
+      if (typeof checked === 'undefined') setIsChecked(event.currentTarget.checked);
       onChange && onChange(event);
     },
-    [onChange]
+    [onChange, checked]
   );
 
   return (
     <label
       className={classNames('Checkbox', className, {
-        'Checkbox--checked': checked
+        'Checkbox--checked': isChecked
       })}
     >
       <span className='Checkbox__indicator'>


### PR DESCRIPTION
Make the `Checkbox` component update when the `checked` property is changed.
See https://github.com/ModaOperandi/discovery/pull/633#discussion_r395190643 where @jmcriffey had to force rerender the components in order to get the checkboxes updated.