### PR TITLE
fix(select): skip disabled options on keyboard navigation

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -59,7 +59,8 @@ export const Select: React.FC<SelectProps> = ({
   onChange,
   ...rest
 }) => {
-  const initialValue = value || options[0].value;
+  const initialValue =
+    value || options.find((option) => !option.disabled)?.value || options[0].value;
   const [state, dispatch] = useReducer(reducer, {
     value: initialValue,
     focused: initialValue,

--- a/src/components/Select/SelectOptions.tsx
+++ b/src/components/Select/SelectOptions.tsx
@@ -26,10 +26,10 @@ export const SelectOptions: React.FC<SelectOptionsProps> = ({
   className,
   ...rest
 }) => {
-  const { index: activeIndex, selected: activeOption } = useKeyboardListNavigation({
-    list: options,
+  const { selected: activeOption } = useKeyboardListNavigation({
+    list: options.filter((option) => !option.disabled),
     onEnter: onSelect,
-    extractValue: option => option.label.toLowerCase()
+    extractValue: (option) => option.label.toLowerCase(),
   });
 
   const ref = useRef<HTMLUListElement>(null);
@@ -39,8 +39,8 @@ export const SelectOptions: React.FC<SelectOptionsProps> = ({
   }, []);
 
   useUpdateEffect(() => {
-    onFocus && onFocus(options[activeIndex]);
-  }, [activeIndex, onFocus, options]);
+    onFocus && onFocus(activeOption);
+  }, [activeOption, onFocus]);
 
   return (
     <ul
@@ -52,12 +52,12 @@ export const SelectOptions: React.FC<SelectOptionsProps> = ({
       aria-activedescendant={`SelectOption--${activeOption.value}-${idRef}`}
       {...rest}
     >
-      {options.map((option, index) => (
+      {options.map((option) => (
         <SelectOption
           id={`SelectOption--${option.value}-${idRef}`}
           key={option.value}
           option={option}
-          active={activeIndex === index}
+          active={activeOption.value === option.value}
           selected={selectedOption.value === option.value}
           onClick={onSelect}
         >


### PR DESCRIPTION
Oops, I forgot the keyboard navigation here.

![select](https://user-images.githubusercontent.com/18576413/78798128-4a466d80-79c1-11ea-9ff7-df103a0d9580.gif)
