### PR TITLE
fix(select): avoids clobbering the global esc key handler

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -96,9 +96,11 @@ export const Select: React.FC<SelectProps> = ({
   }, []);
 
   useEffect(() => {
-    document.addEventListener('keydown', handleKeyDown);
+    const el = selectRef.current;
+    if (!el) return;
+    el.addEventListener('keydown', handleKeyDown);
     return () => {
-      document.removeEventListener('keydown', handleKeyDown);
+      el.removeEventListener('keydown', handleKeyDown);
     };
   }, [handleKeyDown]);
 


### PR DESCRIPTION
Started off debugging the modal and landed on this; was intercepting `esc`, globally if it was on a specific page.