### PR TITLE
feat(popover): add more positioning options

### DIFF
--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -28,7 +28,9 @@
   &--anchor-topLeft {
     #{$self}__content {
       top: 100%;
+      bottom: auto;
       left: 0;
+      right: auto;
       transform: translateY($offset);
     }
   }
@@ -36,7 +38,9 @@
   &--anchor-topCenter {
     #{$self}__content {
       top: 100%;
+      bottom: auto;
       left: 50%;
+      right: auto;
       transform: translate(-50%, $offset);
     }
   }
@@ -44,6 +48,8 @@
   &--anchor-topRight {
     #{$self}__content {
       top: 100%;
+      bottom: auto;
+      left: auto;
       right: 0;
       transform: translateY($offset);
     }
@@ -51,23 +57,29 @@
 
   &--anchor-bottomLeft {
     #{$self}__content {
+      top: auto;
       bottom: 100%;
       left: 0;
+      right: auto;
       transform: translateY(-#{$offset});
     }
   }
 
   &--anchor-bottomCenter {
     #{$self}__content {
+      top: auto;
       bottom: 100%;
       left: 50%;
+      right: auto;
       transform: translate(-50%, -#{$offset});
     }
   }
 
   &--anchor-bottomRight {
     #{$self}__content {
+      top: auto;
       bottom: 100%;
+      left: auto;
       right: 0;
       transform: translateY(-#{$offset});
     }
@@ -79,7 +91,9 @@
     #{$self}__caret {
       &:after,
       &:before {
+        top: auto;
         bottom: -($border-width + $offset);
+        border-top: none;
         border-bottom: $caret-size solid color(snow);
       }
 
@@ -96,7 +110,9 @@
       &:after,
       &:before {
         top: -($border-width + $offset);
+        bottom: auto;
         border-top: $caret-size solid color(snow);
+        border-bottom: none;
       }
 
       &:before {
@@ -107,7 +123,7 @@
 
   &__trigger {
     position: relative;
-    display: inline-block;
+    display: block;
   }
 
   &__caret {

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -10,8 +10,6 @@
 
   &__content {
     position: absolute;
-    top: 100%;
-    transform: translateY($offset);
     background-color: color(snow);
     border: $border-width solid color(elephant);
     z-index: 1;
@@ -27,15 +25,83 @@
     }
   }
 
-  &--anchor-right {
+  &--anchor-topLeft {
     #{$self}__content {
-      right: 0;
+      top: 100%;
+      left: 0;
+      transform: translateY($offset);
     }
   }
 
-  &--anchor-left {
+  &--anchor-topCenter {
     #{$self}__content {
+      top: 100%;
+      left: 50%;
+      transform: translate(-50%, $offset);
+    }
+  }
+
+  &--anchor-topRight {
+    #{$self}__content {
+      top: 100%;
+      right: 0;
+      transform: translateY($offset);
+    }
+  }
+
+  &--anchor-bottomLeft {
+    #{$self}__content {
+      bottom: 100%;
       left: 0;
+      transform: translateY(-#{$offset});
+    }
+  }
+
+  &--anchor-bottomCenter {
+    #{$self}__content {
+      bottom: 100%;
+      left: 50%;
+      transform: translate(-50%, -#{$offset});
+    }
+  }
+
+  &--anchor-bottomRight {
+    #{$self}__content {
+      bottom: 100%;
+      right: 0;
+      transform: translateY(-#{$offset});
+    }
+  }
+
+  &--anchor-topLeft,
+  &--anchor-topCenter,
+  &--anchor-topRight {
+    #{$self}__caret {
+      &:after,
+      &:before {
+        bottom: -($border-width + $offset);
+        border-bottom: $caret-size solid color(snow);
+      }
+
+      &:before {
+        border-bottom: $caret-size solid color(ink);
+      }
+    }
+  }
+
+  &--anchor-bottomLeft,
+  &--anchor-bottomCenter,
+  &--anchor-bottomRight {
+    #{$self}__caret {
+      &:after,
+      &:before {
+        top: -($border-width + $offset);
+        border-top: $caret-size solid color(snow);
+      }
+
+      &:before {
+        border-top: $caret-size solid color(ink);
+      }
     }
   }
 
@@ -54,16 +120,10 @@
     &:before {
       content: '';
       position: absolute;
-      bottom: -($border-width + $offset);
       left: 50%;
       transform: translateX(-50%);
       border-left: $caret-size solid transparent;
       border-right: $caret-size solid transparent;
-      border-bottom: $caret-size solid color(snow);
-    }
-
-    &:before {
-      border-bottom: $caret-size solid color(ink);
     }
   }
 }

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -15,19 +15,21 @@ const Content = (
 );
 
 export const Default = () => (
-  <States<Partial<PopoverProps>>
-    states={[
-      {},
-      { anchor: 'topCenter' },
-      { anchor: 'topRight' },
-      { anchor: 'bottomLeft' },
-      { anchor: 'bottomCenter' },
-      { anchor: 'bottomRight' },
-      { open: true },
-    ]}
-  >
-    <Popover content={Content} style={{ textAlign: 'center' }}>
-      <Text>Hover over me</Text>
-    </Popover>
-  </States>
+  <div style={{ textAlign: 'center' }}>
+    <States<Partial<PopoverProps>>
+      states={[
+        {},
+        { anchor: 'topCenter' },
+        { anchor: 'topRight' },
+        { anchor: 'bottomLeft' },
+        { anchor: 'bottomCenter' },
+        { anchor: 'bottomRight' },
+        { open: true },
+      ]}
+    >
+      <Popover content={Content} style={{ display: 'inline-block' }}>
+        <Text>Hover over me</Text>
+      </Popover>
+    </States>
+  </div>
 );

--- a/src/components/Popover/Popover.stories.tsx
+++ b/src/components/Popover/Popover.stories.tsx
@@ -15,8 +15,18 @@ const Content = (
 );
 
 export const Default = () => (
-  <States<Partial<PopoverProps>> states={[{}, { anchor: 'right' }, { open: true }]}>
-    <Popover content={Content}>
+  <States<Partial<PopoverProps>>
+    states={[
+      {},
+      { anchor: 'topCenter' },
+      { anchor: 'topRight' },
+      { anchor: 'bottomLeft' },
+      { anchor: 'bottomCenter' },
+      { anchor: 'bottomRight' },
+      { open: true },
+    ]}
+  >
+    <Popover content={Content} style={{ textAlign: 'center' }}>
       <Text>Hover over me</Text>
     </Popover>
   </States>

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -6,7 +6,7 @@ export type PopoverProps = React.HTMLAttributes<HTMLDivElement> & {
   content: JSX.Element;
   children: JSX.Element;
   open?: boolean;
-  anchor?: 'left' | 'right';
+  anchor?: 'topLeft' | 'topCenter' | 'topRight' | 'bottomLeft' | 'bottomCenter' | 'bottomRight';
 };
 
 export const POPOVER_MOUSEOUT_DELAY_MS = 200;
@@ -16,7 +16,7 @@ export const Popover: React.FC<PopoverProps> = ({
   children,
   content,
   open = false,
-  anchor = 'left',
+  anchor = 'topLeft',
   ...rest
 }) => {
   const [isOpen, setOpen] = useState(open);


### PR DESCRIPTION
`anchor` can now be 'topLeft', 'topCenter', 'topRight', 'bottomLeft', 'bottomCenter', 'bottomRight'.

e.g. 'bottomCenter':
![image](https://user-images.githubusercontent.com/18576413/79566811-d6d8e600-80bb-11ea-82db-9681ca985607.png)

BREAKING CHANGE: anchor: 'left' is now anchor: 'topLeft' and anchor: 'right' is anchor: 'topRight'