### PR TITLE
fix(popover): increase offset

### DIFF
--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -4,7 +4,7 @@
   $self: &;
   $caret-size: space(2);
   $border-width: 1rem / 16;
-  $offset: space(1);
+  $offset: space(2);
 
   position: relative;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2518,16 +2518,6 @@
     regexpp "^3.0.0"
     tsutils "^3.17.1"
 
-"@typescript-eslint/experimental-utils@2.28.0":
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.28.0.tgz#1fd0961cd8ef6522687b4c562647da6e71f8833d"
-  integrity sha512-4SL9OWjvFbHumM/Zh/ZeEjUFxrYKtdCi7At4GyKTbQlrj1HcphIDXlje4Uu4cY+qzszR5NdVin4CCm6AXCjd6w==
-  dependencies:
-    "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.28.0"
-    eslint-scope "^5.0.0"
-    eslint-utils "^2.0.0"
-
 "@typescript-eslint/experimental-utils@2.29.0":
   version "2.29.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.29.0.tgz#3cb8060de9265ba131625a96bbfec31ba6d4a0fe"
@@ -2547,19 +2537,6 @@
     "@typescript-eslint/experimental-utils" "2.29.0"
     "@typescript-eslint/typescript-estree" "2.29.0"
     eslint-visitor-keys "^1.1.0"
-
-"@typescript-eslint/typescript-estree@2.28.0":
-  version "2.28.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.28.0.tgz#d34949099ff81092c36dc275b6a1ea580729ba00"
-  integrity sha512-HDr8MP9wfwkiuqzRVkuM3BeDrOC4cKbO5a6BymZBHUt5y/2pL0BXD6I/C/ceq2IZoHWhcASk+5/zo+dwgu9V8Q==
-  dependencies:
-    debug "^4.1.1"
-    eslint-visitor-keys "^1.1.0"
-    glob "^7.1.6"
-    is-glob "^4.0.1"
-    lodash "^4.17.15"
-    semver "^6.3.0"
-    tsutils "^3.17.1"
 
 "@typescript-eslint/typescript-estree@2.29.0":
   version "2.29.0"


### PR DESCRIPTION
While working with Popovers I realized that the offset is too small, see this example:

Before:
![image](https://user-images.githubusercontent.com/18576413/79850917-40fbce80-83cd-11ea-8f46-2f27ff8e86fb.png)

After:
![image](https://user-images.githubusercontent.com/18576413/79850564-ccc12b00-83cc-11ea-82ce-7d79e58bf62d.png)

I added padding to some elements to 'fix' this, so after this is merged, I'll need to remove those paddings too in discovery.