### PR TITLE
fix: modal and radiobutton styles

### DIFF
--- a/src/components/Modal/Modal.scss
+++ b/src/components/Modal/Modal.scss
@@ -15,5 +15,14 @@
   &--overlay {
     align-items: baseline;
     background: rgba(255, 255, 255, 0.9);
+    padding: spacing(8, 6);
+
+    @include breakpoint(sm, $prop: max-width) {
+      padding: spacing(8, 4);
+    }
+
+    @include breakpoint(xs, $prop: max-width) {
+      padding: spacing(8, 2);
+    }
   }
 }

--- a/src/components/RadioButton/RadioButton.scss
+++ b/src/components/RadioButton/RadioButton.scss
@@ -7,7 +7,7 @@
   @include stack(2, $direction: horizontal);
 
   position: relative;
-  align-items: flex-start;
+  align-items: center;
   user-select: none;
   cursor: pointer;
   color: color(ink);
@@ -16,7 +16,6 @@
     position: relative;
     width: $radio-button-size;
     height: $radio-button-size;
-    margin-top: space(1) / 2;
     flex-shrink: 0;
     border: 1px solid;
     border-radius: 50%;


### PR DESCRIPTION
Add some padding to ModalOverlay.
Remove the small margin from RadioButton and center the contents vertically.

