### PR TITLE
fix(select): make height match input

### DIFF
--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -34,6 +34,7 @@
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
+    line-height: 1.8;
     cursor: pointer;
 
     &:hover {


### PR DESCRIPTION
Make the height of `Select` match `TextInput`.