### PR TITLE
fix(<clickable />): fix wrapping

### DIFF
--- a/src/components/Clickable/Clickable.scss
+++ b/src/components/Clickable/Clickable.scss
@@ -14,4 +14,5 @@
   font-size: __dangerously-get-font-size__(2);
   padding: 0;
   text-decoration: none;
+  white-space: nowrap;
 }


### PR DESCRIPTION
I don't think that we're wrapping anything that's clickable and if so, we can overwrite the prop when specially needed.