### PR TITLE
fix(select and clickable): allow arrow click and label pointer view

### DIFF
--- a/src/components/Clickable/Clickable.scss
+++ b/src/components/Clickable/Clickable.scss
@@ -15,4 +15,8 @@
   padding: 0;
   text-decoration: none;
   white-space: nowrap;
+
+  > label {
+    cursor: inherit;
+  }
 }

--- a/src/components/Clickable/Clickable.tsx
+++ b/src/components/Clickable/Clickable.tsx
@@ -32,7 +32,7 @@ export const Clickable = React.forwardRef(
 
     if (isLink(props)) return <Link {...props} ref={ref as React.Ref<HTMLAnchorElement>} />;
     if (isAnchor(props)) return <a {...props} ref={ref as React.Ref<HTMLAnchorElement>} />;
-    if (isButton(props)) return <button {...props} ref={ref as React.Ref<HTMLButtonElement>} />;
+    if (isButton(props)) return <button {...props} ref={ref as React.Ref<HTMLButtonElement>} tabIndex={0}/>;
 
     return null;
   }

--- a/src/components/Clickable/Clickable.tsx
+++ b/src/components/Clickable/Clickable.tsx
@@ -32,7 +32,7 @@ export const Clickable = React.forwardRef(
 
     if (isLink(props)) return <Link {...props} ref={ref as React.Ref<HTMLAnchorElement>} />;
     if (isAnchor(props)) return <a {...props} ref={ref as React.Ref<HTMLAnchorElement>} />;
-    if (isButton(props)) return <button {...props} ref={ref as React.Ref<HTMLButtonElement>} tabIndex={0}/>;
+    if (isButton(props)) return <button {...props} ref={ref as React.Ref<HTMLButtonElement>} />;
 
     return null;
   }

--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -50,6 +50,7 @@
   }
 
   &__icon {
+    pointer-events: none;
     position: absolute;
     right: space(4);
     top: 50%;


### PR DESCRIPTION
Now in select boxes the arrow on the right is clickable as well. also the label inside
buttons/clickables will have the same curser behavior as the parent