### PR TITLE
feat(breadcrumbs): microdata improvements

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumb/Breadcrumb.tsx
+++ b/src/components/Breadcrumbs/Breadcrumb/Breadcrumb.tsx
@@ -1,14 +1,28 @@
 import React from 'react';
+import { ControlLink, ControlLinkProps } from '../../ControlLink';
 
 import './Breadcrumb.scss';
 
-export const Breadcrumb: React.FC = ({ children }) => (
+export type BreadcrumbProps = ControlLinkProps & {
+  position?: number;
+  to?: string;
+  href?: string;
+};
+
+export const Breadcrumb: React.FC<BreadcrumbProps> = ({ children, position, ...rest }) => (
   <li
     className='Breadcrumb'
     itemProp='itemListElement'
     itemScope
     itemType='http://schema.org/ListItem'
   >
-    {children}
+    {rest.to || rest.href ? (
+      <ControlLink itemProp='item' {...rest}>
+        <span itemProp='name'>{children}</span>
+      </ControlLink>
+    ) : (
+      <span itemProp='name'>{children}</span>
+    )}
+    {position != null && <meta itemProp='position' content={String(position)} />}
   </li>
 );

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { States } from 'storybook-states';
 
-import { Breadcrumbs, BreadcrumbsProps } from './Breadcrumbs';
+import { Breadcrumbs, Breadcrumb, BreadcrumbsProps } from './index';
 
 export default { title: 'Components|Breadcrumbs' };
 
 export const Default = () => (
   <States<BreadcrumbsProps>>
     <Breadcrumbs>
-      <a href='#men'>Men</a>
-      <a href='#clothing'>Clothing</a>
-      <a href='#coats-jackets'>Coats &amp; Jackets</a>
-      Zippy Safari Straight-Leg Wool Jumpsuit
+      <Breadcrumb href='#men'>Men</Breadcrumb>
+      <Breadcrumb href='#clothing'>Clothing</Breadcrumb>
+      <Breadcrumb href='#coats-jackets'>Coats &amp; Jackets</Breadcrumb>
+      <Breadcrumb>Zippy Safari Straight-Leg Wool Jumpsuit</Breadcrumb>
     </Breadcrumbs>
   </States>
 );
@@ -19,10 +19,10 @@ export const Default = () => (
 export const Mobile = () => (
   <States<BreadcrumbsProps>>
     <Breadcrumbs>
-      <a href='#men'>Men</a>
-      <a href='#clothing'>Clothing</a>
-      <a href='#coats-jackets'>Coats &amp; Jackets</a>
-      Zippy Safari Straight-Leg Wool Jumpsuit
+      <Breadcrumb href='#men'>Men</Breadcrumb>
+      <Breadcrumb href='#clothing'>Clothing</Breadcrumb>
+      <Breadcrumb href='#coats-jackets'>Coats &amp; Jackets</Breadcrumb>
+      <Breadcrumb>Zippy Safari Straight-Leg Wool Jumpsuit</Breadcrumb>
     </Breadcrumbs>
   </States>
 );

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,19 +1,19 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { Breadcrumbs } from './Breadcrumbs';
+import { Breadcrumbs, Breadcrumb } from './index';
 
 describe('Breadcrumbs', () => {
   it('wraps elements with microdata tags', () => {
     const component = shallow(
       <Breadcrumbs>
-        <a>One</a>
-        <a>Two</a>
-        <span>Three</span>
+        <Breadcrumb href='/one'>One</Breadcrumb>
+        <Breadcrumb href='/two'>Two</Breadcrumb>
+        <Breadcrumb>Three</Breadcrumb>
       </Breadcrumbs>
     );
     expect(component.html()).toEqual(
-      '<ol itemscope="" itemType="http://schema.org/BreadcrumbList" class="Breadcrumbs"><li class="Breadcrumb" itemProp="itemListElement" itemscope="" itemType="http://schema.org/ListItem"><a>One</a></li><li class="Breadcrumb" itemProp="itemListElement" itemscope="" itemType="http://schema.org/ListItem"><a>Two</a></li><li class="Breadcrumb" itemProp="itemListElement" itemscope="" itemType="http://schema.org/ListItem"><span>Three</span></li></ol>'
+      '<ol itemscope="" itemType="http://schema.org/BreadcrumbList" class="Breadcrumbs"><li class="Breadcrumb" itemProp="itemListElement" itemscope="" itemType="http://schema.org/ListItem"><a itemProp="item" href="/one" class="Clickable ControlLink ControlLink--underlined"><span itemProp="name">One</span></a><meta itemProp="position" content="1"/></li><li class="Breadcrumb" itemProp="itemListElement" itemscope="" itemType="http://schema.org/ListItem"><a itemProp="item" href="/two" class="Clickable ControlLink ControlLink--underlined"><span itemProp="name">Two</span></a><meta itemProp="position" content="2"/></li><li class="Breadcrumb" itemProp="itemListElement" itemscope="" itemType="http://schema.org/ListItem"><span itemProp="name">Three</span><meta itemProp="position" content="3"/></li></ol>'
     );
   });
 });

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -1,20 +1,31 @@
-import React, { Children } from 'react';
+import React, { Children, cloneElement, isValidElement } from 'react';
 import classNames from 'classnames';
-import { Breadcrumb } from './Breadcrumb';
 
 import './Breadcrumbs.scss';
 
 export type BreadcrumbsProps = React.OlHTMLAttributes<HTMLOListElement>;
 
-export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ children, className, ...rest }) => (
-  <ol
-    itemScope
-    itemType='http://schema.org/BreadcrumbList'
-    className={classNames('Breadcrumbs', className)}
-    {...rest}
-  >
-    {Children.map(children, (child, i) => (
-      child && <Breadcrumb key={i}>{child}</Breadcrumb>
-    ))}
-  </ol>
-);
+export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({ children, className, ...rest }) => {
+  let position = 0;
+
+  return (
+    <ol
+      itemScope
+      itemType='http://schema.org/BreadcrumbList'
+      className={classNames('Breadcrumbs', className)}
+      {...rest}
+    >
+      {Children.map(children, (child, index) => {
+        if (isValidElement(child)) {
+          position = position + 1;
+          return cloneElement(
+            child,
+            { ...child.props, key: index, position },
+            child.props.children
+          );
+        }
+        return child;
+      })}
+    </ol>
+  );
+};

--- a/src/components/Breadcrumbs/index.ts
+++ b/src/components/Breadcrumbs/index.ts
@@ -1,1 +1,2 @@
 export * from './Breadcrumbs';
+export * from './Breadcrumb';


### PR DESCRIPTION
Adds `<meta itemprop="position" />`, `itemprop="item"` to the anchors and `itemprop="name"` to the
names.

BREAKING CHANGE: The props api have changed, now you need to explicitly render `<Breadcrumb>`
components inside of `<Breadcrumbs>`.

DOOR-120