### PR TITLE
fix(inputs and selects): ios devices need font size 16

### DIFF
--- a/src/components/Select/Select.scss
+++ b/src/components/Select/Select.scss
@@ -3,6 +3,11 @@
 .Select {
   $self: &;
 
+  //ios devices zoom in if inputs are smaller than 16px
+  @include breakpoint(sm, $prop: max-width) {
+    @include text(h6);
+  }
+
   min-height: 2.5625rem;
   position: relative;
   display: flex;
@@ -25,6 +30,11 @@
 
   &__value {
     @include text(body1);
+
+    //ios devices zoom in if inputs are smaller than 16px
+    @include breakpoint(sm, $prop: max-width) {
+      @include text(h6);
+    }
 
     display: block;
     width: 100%;

--- a/src/mixins/input-styles/_input-styles.scss
+++ b/src/mixins/input-styles/_input-styles.scss
@@ -1,6 +1,11 @@
 @mixin input-styles() {
   @include text(body1);
 
+  //ios devices zoom in if inputs are smaller than 16px
+  @include breakpoint(sm, $prop: max-width) {
+    @include text(h6);
+  }
+
   appearance: none;
   line-height: 1;
   width: 100%;


### PR DESCRIPTION
if inputs are font-size < 16px, ios devices automatically zoom the user in and won't zoom out