### PR TITLE
fix(button.scss): button focus style

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -30,23 +30,22 @@
     &#{$self}--hover,
     &:hover {
       color: color(snow);
-      border-color: color(cement);
-      background-color: color(cement);
+      border-color: color(fog, 0.32);
+      background: linear-gradient(0deg, color(fog, 0.32), color(fog, 0.32)), color(ink);
     }
 
     &#{$self}--focus,
     &:focus {
-      text-decoration: underline;
       color: color(snow);
-      border-color: color(fog);
-      background-color: color(fog);
+      border-color: color(fog, 0.12);
+      background: linear-gradient(0deg, color(snow, 0.12), color(snow, 0.12)), color(ink);
     }
 
     &#{$self}--disabled,
     &:disabled {
       color: color(ink);
-      border-color: color(elephant);
-      background-color: color(elephant);
+      border-color: color(noise);
+      background-color: color(noise);
       cursor: default;
       pointer-events: none;
     }
@@ -61,22 +60,21 @@
     &:hover {
       color: color(ink);
       border-color: color(ink);
-      background-color: color(noise);
+      background-color: color(noise, 0.32);
     }
 
     &#{$self}--focus,
     &:focus {
-      text-decoration: underline;
       color: color(ink);
       border-color: color(ink);
-      background-color: color(elephant);
+      background-color: color(noise);
     }
 
     &#{$self}--disabled,
     &:disabled {
       color: color(cement);
-      border-color: color(cement);
-      background-color: color(elephant);
+      border-color: color(fog);
+      background-color: color(noise);
       cursor: default;
       pointer-events: none;
     }


### PR DESCRIPTION
Button focus styling was confused with the disabled state, and also updated them to reflect the buttons from the core library: https://www.figma.com/file/FrC7k1AZjKH07OhiDYhBpM/Om-Core-Library?node-id=1417%3A0

Primary before:
<img width="425" alt="Screenshot 2020-08-28 at 1 58 35 PM" src="https://user-images.githubusercontent.com/20396500/91554124-2ddaab80-e937-11ea-8c83-eb0148aa62a9.png">
Primary after:
<img width="270" alt="Screenshot 2020-08-31 at 11 05 15 AM" src="https://user-images.githubusercontent.com/20396500/91698158-ec3a4280-eb7a-11ea-9f42-b3453b068baa.png">

Secondry before:
<img width="425" alt="Screenshot 2020-08-28 at 1 58 38 PM" src="https://user-images.githubusercontent.com/20396500/91554120-2ca97e80-e937-11ea-8afb-619b780f3110.png">
Secondry after:
<img width="270" alt="Screenshot 2020-08-31 at 11 05 10 AM" src="https://user-images.githubusercontent.com/20396500/91698169-f0666000-eb7a-11ea-8fd0-956df89bc249.png">


DOOR-504