### PR TITLE
feat(select): improve keyboard navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,8 @@
     "proportional-scale": "^4.0.0",
     "react-focus-on": "^3.3.0",
     "react-input-mask": "^2.0.4",
-    "use-cursor": "^1.0.0",
-    "use-keyboard-list-navigation": "^2.0.0"
+    "scroll-into-view-if-needed": "^2.2.26",
+    "use-cursor": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.9.0",
@@ -68,6 +68,7 @@
     "@storybook/addons": "^6.0.17",
     "@storybook/react": "^6.0.17",
     "@testing-library/react": "^11.0.2",
+    "@testing-library/react-hooks": "^3.4.1",
     "@testing-library/user-event": "^12.1.3",
     "@types/credit-card-type": "^9.0.0",
     "@types/enzyme": "^3.10.3",

--- a/src/components/Select/SelectOption.tsx
+++ b/src/components/Select/SelectOption.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useRef, useEffect } from 'react';
 import classNames from 'classnames';
+import scrollIntoView from 'scroll-into-view-if-needed';
 import { SelectableOption } from './Select';
 import './SelectOption.scss';
 
@@ -17,6 +18,8 @@ export const SelectOption: React.FC<SelectOptionProps> = ({
   onClick,
   className
 }) => {
+  const ref = useRef<HTMLLIElement>(null);
+
   const handleClick = useCallback(
     event => {
       event.preventDefault();
@@ -25,8 +28,15 @@ export const SelectOption: React.FC<SelectOptionProps> = ({
     [onClick, option]
   );
 
+  useEffect(() => {
+    if (active && ref.current) {
+      scrollIntoView(ref.current, { scrollMode: 'if-needed', block: 'nearest' });
+    }
+  }, [active, ref]);
+
   return (
     <li
+      ref={ref}
       className={classNames('SelectOption', className, {
         'SelectOption--active': active,
         'SelectOption--selected': selected,

--- a/src/components/Select/SelectOptions.tsx
+++ b/src/components/Select/SelectOptions.tsx
@@ -1,9 +1,9 @@
 import React, { useRef, useEffect } from 'react';
 import classNames from 'classnames';
-import { useKeyboardListNavigation } from 'use-keyboard-list-navigation';
 import { SelectOption } from './SelectOption';
 import { SelectableOption } from './Select';
 import './SelectOptions.scss';
+import { useKeyboardListNavigation } from '../../hooks/useKeyboardListNavigation';
 import { useUpdateEffect } from '../../hooks/useUpdateEffect';
 
 export type SelectOptionsProps = Omit<
@@ -27,9 +27,10 @@ export const SelectOptions: React.FC<SelectOptionsProps> = ({
   ...rest
 }) => {
   const { selected: activeOption } = useKeyboardListNavigation({
-    list: options.filter((option) => !option.disabled),
+    list: options.filter(option => !option.disabled),
+    defaultSelected: selectedOption,
     onEnter: ({ element }) => onSelect(element),
-    extractValue: (option) => option?.label.toLowerCase(),
+    extractValue: option => option?.label.toLowerCase()
   });
 
   const ref = useRef<HTMLUListElement>(null);
@@ -52,7 +53,7 @@ export const SelectOptions: React.FC<SelectOptionsProps> = ({
       aria-activedescendant={`SelectOption--${activeOption?.value}-${idRef}`}
       {...rest}
     >
-      {options.map((option) => (
+      {options.map(option => (
         <SelectOption
           id={`SelectOption--${option.value}-${idRef}`}
           key={option.value}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from './useUpdateEffect';
 export * from './useBreakpoint';
+export * from './useKeyboardListNavigation';

--- a/src/hooks/useKeyboardListNavigation.spec.ts
+++ b/src/hooks/useKeyboardListNavigation.spec.ts
@@ -1,0 +1,270 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { fireEvent } from '@testing-library/react';
+import { useKeyboardListNavigation } from './useKeyboardListNavigation';
+import { useRef } from 'react';
+
+describe('useKeyboardListNavigation', () => {
+  const list = ['first', 'second', 'third', 'fourth'];
+  const noop = () => {};
+
+  it('selects the first element', () => {
+    const { result } = renderHook(() => useKeyboardListNavigation({ list, onEnter: noop }));
+
+    expect(result.current.cursor).toBe(0);
+    expect(result.current.index).toBe(0);
+    expect(result.current.selected).toBe('first');
+  });
+
+  it('selects the defaultSelected element', () => {
+    const { result } = renderHook(() =>
+      useKeyboardListNavigation({ list, defaultSelected: 'second', onEnter: noop })
+    );
+
+    expect(result.current.cursor).toBe(1);
+    expect(result.current.index).toBe(1);
+    expect(result.current.selected).toBe('second');
+  });
+
+  it('selects the second element when the "ArrowDown" key is pressed', () => {
+    const { result } = renderHook(() => useKeyboardListNavigation({ list, onEnter: noop }));
+
+    expect(result.current.cursor).toBe(0);
+    expect(result.current.index).toBe(0);
+    expect(result.current.selected).toBe('first');
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'ArrowDown' });
+    });
+
+    expect(result.current.cursor).toBe(1);
+    expect(result.current.index).toBe(1);
+    expect(result.current.selected).toBe('second');
+  });
+
+  it('selects the third element when the "ArrowDown" key is pressed twice', () => {
+    const { result } = renderHook(() => useKeyboardListNavigation({ list, onEnter: noop }));
+
+    expect(result.current.cursor).toBe(0);
+    expect(result.current.index).toBe(0);
+    expect(result.current.selected).toBe('first');
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'ArrowDown' });
+      fireEvent.keyDown(window, { key: 'ArrowDown' });
+    });
+
+    expect(result.current.cursor).toBe(2);
+    expect(result.current.index).toBe(2);
+    expect(result.current.selected).toBe('third');
+  });
+
+  it('selects the last element when the "ArrowUp" key is pressed initially', () => {
+    const { result } = renderHook(() => useKeyboardListNavigation({ list, onEnter: noop }));
+
+    expect(result.current.cursor).toBe(0);
+    expect(result.current.index).toBe(0);
+    expect(result.current.selected).toBe('first');
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'ArrowUp' });
+    });
+
+    expect(result.current.cursor).toBe(-1);
+    expect(result.current.index).toBe(3);
+    expect(result.current.selected).toBe('fourth');
+  });
+
+  it('selects the last element when the "End" key is pressed no matter where in the list one is', () => {
+    const { result } = renderHook(() => useKeyboardListNavigation({ list, onEnter: noop }));
+
+    expect(result.current.cursor).toBe(0);
+    expect(result.current.index).toBe(0);
+    expect(result.current.selected).toBe('first');
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'End' });
+    });
+
+    expect(result.current.cursor).toBe(3);
+    expect(result.current.index).toBe(3);
+    expect(result.current.selected).toBe('fourth');
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'ArrowUp' });
+      fireEvent.keyDown(window, { key: 'ArrowUp' });
+    });
+
+    expect(result.current.cursor).toBe(1);
+    expect(result.current.index).toBe(1);
+    expect(result.current.selected).toBe('second');
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'End' });
+    });
+
+    expect(result.current.cursor).toBe(3);
+    expect(result.current.index).toBe(3);
+    expect(result.current.selected).toBe('fourth');
+  });
+
+  it('selects the first element when the "Home" key is pressed no matter where in the list one is', () => {
+    const { result } = renderHook(() =>
+      useKeyboardListNavigation({
+        list,
+        onEnter: noop,
+        waitForInteractive: true
+      })
+    );
+
+    expect(result.current.cursor).toBe(0);
+    expect(result.current.index).toBe(-1);
+    expect(result.current.selected).toBeUndefined();
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Home' });
+    });
+
+    expect(result.current.cursor).toBe(0);
+    expect(result.current.index).toBe(0);
+    expect(result.current.selected).toBe('first');
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'ArrowUp' });
+      fireEvent.keyDown(window, { key: 'ArrowUp' });
+    });
+
+    expect(result.current.cursor).toBe(-2);
+    expect(result.current.index).toBe(2);
+    expect(result.current.selected).toBe('third');
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Home' });
+    });
+
+    expect(result.current.cursor).toBe(0);
+    expect(result.current.index).toBe(0);
+    expect(result.current.selected).toBe('first');
+  });
+
+  it('selects the third item when the t key is pressed', () => {
+    const { result } = renderHook(() =>
+      useKeyboardListNavigation({
+        list,
+        onEnter: noop
+      })
+    );
+
+    expect(result.current.cursor).toBe(0);
+    expect(result.current.index).toBe(0);
+    expect(result.current.selected).toBe('first');
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 't' });
+    });
+
+    expect(result.current.cursor).toBe(2);
+    expect(result.current.index).toBe(2);
+    expect(result.current.selected).toBe('third');
+  });
+
+  it('calls `onEnter` with the selected items when the "Enter" key is pressed', () => {
+    const onEnter = jest.fn();
+    renderHook(() => useKeyboardListNavigation({ list, onEnter }));
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Enter' });
+    });
+
+    expect(onEnter).toBeCalledTimes(1);
+    expect(onEnter).toHaveBeenCalledWith({
+      element: 'first',
+      event: expect.anything(),
+      index: 0,
+      state: { cursor: 0, interactive: false, length: 4 }
+    });
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'ArrowDown' });
+      fireEvent.keyDown(window, { key: 'ArrowDown' });
+    });
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'Enter' });
+    });
+
+    expect(onEnter).toBeCalledTimes(2);
+    expect(onEnter).toHaveBeenLastCalledWith({
+      element: 'third',
+      event: expect.anything(),
+      index: 2,
+      state: { cursor: 2, interactive: true, length: 4 }
+    });
+  });
+
+  it('supports a focusable ref', () => {
+    const div = document.createElement('div');
+    const { result } = renderHook(() => {
+      const ref = useRef(div);
+      return useKeyboardListNavigation({ list, ref, onEnter: noop });
+    });
+
+    expect(result.current.cursor).toBe(0);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'ArrowDown' });
+    });
+
+    expect(result.current.cursor).toBe(0);
+
+    act(() => {
+      fireEvent.keyDown(div, { key: 'ArrowDown' });
+    });
+
+    expect(result.current.cursor).toBe(1);
+  });
+
+  describe('waitForInteractive', () => {
+    it('returns an invalid index until some interaction takes place', () => {
+      const { result } = renderHook(() =>
+        useKeyboardListNavigation({
+          list,
+          onEnter: noop,
+          waitForInteractive: true
+        })
+      );
+
+      expect(result.current.cursor).toBe(0);
+      expect(result.current.index).toBe(-1);
+      expect(result.current.selected).toBeUndefined();
+
+      act(() => {
+        fireEvent.keyDown(window, { key: 'ArrowDown' });
+      });
+
+      expect(result.current.cursor).toBe(0);
+      expect(result.current.index).toBe(0);
+      expect(result.current.selected).toEqual('first');
+    });
+
+    it('does not trigger `onEnter` if no interaction has taken place', () => {
+      const onEnter = jest.fn();
+      renderHook(() => useKeyboardListNavigation({ list, onEnter, waitForInteractive: true }));
+
+      act(() => {
+        fireEvent.keyDown(window, { key: 'Enter' });
+      });
+
+      expect(onEnter).toBeCalledTimes(0);
+
+      act(() => {
+        fireEvent.keyDown(window, { key: 'ArrowDown' });
+      });
+
+      act(() => {
+        fireEvent.keyDown(window, { key: 'Enter' });
+      });
+
+      expect(onEnter).toBeCalledTimes(1);
+    });
+  });
+});

--- a/src/hooks/useKeyboardListNavigation.ts
+++ b/src/hooks/useKeyboardListNavigation.ts
@@ -1,0 +1,150 @@
+import { useCallback, useEffect, useReducer, useRef } from 'react';
+import { mapCursorToMax } from 'map-cursor-to-max';
+
+export type UseKeyboardListNavigationAction =
+  | { type: 'RESET'; payload: { defaultCursor: number } }
+  | { type: 'INTERACT' }
+  | { type: 'PREV' }
+  | { type: 'NEXT' }
+  | { type: 'FIRST' }
+  | { type: 'LAST' }
+  | { type: 'SET'; payload: { cursor: number } };
+
+export type UseKeyboardListNavigationState = {
+  cursor: number;
+  length: number;
+  interactive: boolean;
+};
+
+const reducer = (
+  state: UseKeyboardListNavigationState,
+  action: UseKeyboardListNavigationAction
+): UseKeyboardListNavigationState => {
+  switch (action.type) {
+    case 'RESET':
+      return { ...state, cursor: action.payload.defaultCursor, interactive: false };
+    case 'INTERACT':
+      return { ...state, interactive: true };
+    case 'PREV':
+      return { ...state, cursor: state.cursor - 1, interactive: true };
+    case 'NEXT':
+      return { ...state, cursor: state.cursor + 1, interactive: true };
+    case 'FIRST':
+      return { ...state, cursor: 0, interactive: true };
+    case 'LAST':
+      return { ...state, cursor: state.length - 1, interactive: true };
+    case 'SET':
+      return { ...state, cursor: action.payload.cursor };
+    default:
+      return state;
+  }
+};
+
+export type UseKeyboardListNavigationProps<T> = {
+  list: T[];
+  defaultSelected?: T;
+  waitForInteractive?: boolean;
+  onEnter({
+    event,
+    element,
+    state,
+    index
+  }: {
+    event: KeyboardEvent;
+    element: T;
+    state: UseKeyboardListNavigationState;
+    index: number;
+  }): void;
+  extractValue?(item: T): string;
+  ref?: React.MutableRefObject<any>;
+};
+
+const IDLE_TIMEOUT_MS = 1000;
+
+export const useKeyboardListNavigation = <T>({
+  list,
+  defaultSelected,
+  onEnter,
+  waitForInteractive = false,
+  ref,
+  extractValue = item => (typeof item === 'string' ? item.toLowerCase() : '')
+}: UseKeyboardListNavigationProps<T>) => {
+  const defaultCursor = defaultSelected ? list.indexOf(defaultSelected) : 0;
+  const [state, dispatch] = useReducer(reducer, {
+    cursor: defaultCursor,
+    length: list.length,
+    interactive: false
+  });
+
+  const searchTerm = useRef('');
+  const idleTimeout = useRef<NodeJS.Timeout | null>(null);
+
+  const index = mapCursorToMax(state.cursor, list.length);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      switch (event.key) {
+        case 'ArrowUp': {
+          event.preventDefault();
+          return dispatch({ type: 'PREV' });
+        }
+        case 'ArrowDown': {
+          event.preventDefault();
+          if (waitForInteractive && !state.interactive) return dispatch({ type: 'INTERACT' });
+          return dispatch({ type: 'NEXT' });
+        }
+        case 'Enter': {
+          if (waitForInteractive && !state.interactive) break;
+          return onEnter({ event, element: list[index], state, index });
+        }
+        case 'Home': {
+          return dispatch({ type: 'FIRST' });
+        }
+        case 'End': {
+          return dispatch({ type: 'LAST' });
+        }
+        default:
+          // allow searching by name
+          if (/^[a-z0-9_-]$/i.test(event.key)) {
+            searchTerm.current = searchTerm.current + event.key;
+
+            const node = list.find(item => extractValue(item).startsWith(searchTerm.current));
+
+            if (node) {
+              dispatch({
+                type: 'SET',
+                payload: { cursor: list.indexOf(node) }
+              });
+            }
+
+            if (idleTimeout.current) clearTimeout(idleTimeout.current);
+
+            idleTimeout.current = setTimeout(() => {
+              searchTerm.current = '';
+            }, IDLE_TIMEOUT_MS);
+          }
+
+          break;
+      }
+    },
+    [index, list, onEnter, state, waitForInteractive, extractValue]
+  );
+
+  useEffect(() => {
+    const el = ref?.current ?? window;
+    el.addEventListener('keydown', handleKeyDown);
+    return () => {
+      el.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [handleKeyDown, ref, idleTimeout]);
+
+  useEffect(() => dispatch({ type: 'RESET', payload: { defaultCursor } }), [list.length]);
+
+  const interactiveIndex = waitForInteractive && !state.interactive ? -1 : index;
+
+  return {
+    ...state,
+    index: interactiveIndex,
+    selected: list[interactiveIndex]
+  };
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1028,7 +1028,7 @@
     core-js-pure "^3.0.0"
     regenerator-runtime "^0.13.4"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.2", "@babel/runtime@^7.10.3", "@babel/runtime@^7.11.2", "@babel/runtime@^7.3.1", "@babel/runtime@^7.3.4", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.4", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2", "@babel/runtime@^7.9.6":
   version "7.11.2"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
   integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
@@ -2391,6 +2391,14 @@
     dom-accessibility-api "^0.5.1"
     pretty-format "^26.4.2"
 
+"@testing-library/react-hooks@^3.4.1":
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.4.1.tgz#1f8ccd21208086ec228d9743fe40b69d0efcd7e5"
+  integrity sha512-LbzvE7oKsVzuW1cxA/aOeNgeVvmHWG2p/WSzalIGyWuqZT3jVcNDT5KPEwy36sUYWde0Qsh32xqIUFXukeywXg==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@types/testing-library__react-hooks" "^3.3.0"
+
 "@testing-library/react@^11.0.2":
   version "11.0.2"
   resolved "https://registry.yarnpkg.com/@testing-library/react/-/react-11.0.2.tgz#4588cc537085907bd1d98b531eb247dbbf57b1cc"
@@ -2722,6 +2730,13 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-test-renderer@*":
+  version "16.9.3"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.3.tgz#96bab1860904366f4e848b739ba0e2f67bcae87e"
+  integrity sha512-wJ7IlN5NI82XMLOyHSa+cNN4Z0I+8/YaLl04uDgcZ+W+ExWCmCiVTLT/7fRNqzy4OhStZcUwIqLNF7q+AdW43Q==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react@*", "@types/react@^16.9.11":
   version "16.9.49"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.49.tgz#09db021cf8089aba0cdb12a49f8021a69cce4872"
@@ -2756,6 +2771,13 @@
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.6.tgz#a9ca4b70a18b270ccb2bc0aaafefd1d486b7ea74"
   integrity sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA==
+
+"@types/testing-library__react-hooks@^3.3.0":
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.4.0.tgz#be148b7fa7d19cd3349c4ef9d9534486bc582fcc"
+  integrity sha512-QYLZipqt1hpwYsBU63Ssa557v5wWbncqL36No59LI7W3nCMYKrLWTnYGn2griZ6v/3n5nKXNYkTeYpqPHY7Ukg==
+  dependencies:
+    "@types/react-test-renderer" "*"
 
 "@types/uglify-js@*":
   version "3.9.3"
@@ -4985,6 +5007,11 @@ component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
   integrity sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+
+compute-scroll-into-view@^1.0.16:
+  version "1.0.16"
+  resolved "https://registry.yarnpkg.com/compute-scroll-into-view/-/compute-scroll-into-view-1.0.16.tgz#5b7bf4f7127ea2c19b750353d7ce6776a90ee088"
+  integrity sha512-a85LHKY81oQnikatZYA90pufpZ6sQx++BoCxOEMsjpZx+ZnaKGQnCyCehTRr/1p9GBIAHTjcU9k71kSYWloLiQ==
 
 concat-map@0.0.1:
   version "0.0.1"
@@ -13306,6 +13333,13 @@ schema-utils@^2.6.5, schema-utils@^2.6.6, schema-utils@^2.7.0, schema-utils@^2.7
     ajv "^6.12.4"
     ajv-keywords "^3.5.2"
 
+scroll-into-view-if-needed@^2.2.26:
+  version "2.2.26"
+  resolved "https://registry.yarnpkg.com/scroll-into-view-if-needed/-/scroll-into-view-if-needed-2.2.26.tgz#e4917da0c820135ff65ad6f7e4b7d7af568c4f13"
+  integrity sha512-SQ6AOKfABaSchokAmmaxVnL9IArxEnLEX9j4wAZw+x4iUTb40q7irtHG3z4GtAWz5veVZcCnubXDBRyLVQaohw==
+  dependencies:
+    compute-scroll-into-view "^1.0.16"
+
 scss-tokenizer@^0.2.3:
   version "0.2.3"
   resolved "https://registry.yarnpkg.com/scss-tokenizer/-/scss-tokenizer-0.2.3.tgz#8eb06db9a9723333824d3f5530641149847ce5d1"
@@ -14965,13 +14999,6 @@ use-isomorphic-layout-effect@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.0.0.tgz#f56b4ed633e1c21cd9fc76fe249002a1c28989fb"
   integrity sha512-JMwJ7Vd86NwAt1jH7q+OIozZSIxA4ND0fx6AsOe2q1H8ooBUp5aN6DvVCqZiIaYU6JaMRJGyR0FO7EBCIsb/Rg==
-
-use-keyboard-list-navigation@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/use-keyboard-list-navigation/-/use-keyboard-list-navigation-2.0.1.tgz#a5ccf2c59e215aec03bfb8eba5ae85ef56ec8c79"
-  integrity sha512-uAIIA0m/oejL4E0qet8jVZZaM/95QlT6SEl5PxUEpKPLoWcSyufqy/S1U0/yx3bPHq4Ny3iBLB3ZN7T4agBKZQ==
-  dependencies:
-    map-cursor-to-max "^1.0.0"
 
 use-latest@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
Allow searching by keywords and scroll active element into view.
Also copied [use-keyboard-list-navigation](https://github.com/dzucconi/use-keyboard-list-navigation) into the repo because I don't have push access to that repo.