### PR TITLE
feat(modal): add shards to props

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ComponentProps } from 'react';
 import { FocusOn } from 'react-focus-on';
 import classNames from 'classnames';
 
@@ -6,11 +6,12 @@ import './Modal.scss';
 
 export type ModalProps = React.HTMLAttributes<HTMLDivElement> & {
   onClose(): void;
+  shards?: ComponentProps<typeof FocusOn>['shards'];
 };
 
-export const Modal: React.FC<ModalProps> = ({ className, children, onClose, ...rest }) => (
+export const Modal: React.FC<ModalProps> = ({ className, children, onClose, shards, ...rest }) => (
   <div className={classNames('Modal', className)} {...rest}>
-    <FocusOn onClickOutside={onClose} onEscapeKey={onClose}>
+    <FocusOn shards={shards} onClickOutside={onClose} onEscapeKey={onClose}>
       {children}
     </FocusOn>
   </div>

--- a/src/components/ModalOverlay/ModalOverlay.tsx
+++ b/src/components/ModalOverlay/ModalOverlay.tsx
@@ -16,6 +16,7 @@ export const ModalOverlay: React.FC<ModalOverlayProps> = ({
   onClose,
   overlayClassName,
   show = true,
+  shards,
   ...rest
 }) => {
   const element = useMemo(
@@ -36,7 +37,11 @@ export const ModalOverlay: React.FC<ModalOverlayProps> = ({
 
   return createPortal(
     <Overlay className={classNames('ModalOverlay', overlayClassName)} show={show} {...rest}>
-      <Modal className={classNames('ModalOverlay__modal', className)} onClose={onClose}>
+      <Modal
+        className={classNames('ModalOverlay__modal', className)}
+        onClose={onClose}
+        shards={shards}
+      >
         <div className={classNames('ModalOverlay__content', contentClassName)}>{children}</div>
       </Modal>
     </Overlay>,


### PR DESCRIPTION
Allow passing in `shards` in props to allow interacting with things like recaptcha while the modal is open.
See [react-focus-on](https://github.com/theKashey/react-focus-on#focuson).