### PR TITLE
fix(overlay): animation

### DIFF
--- a/src/components/Overlay/Overlay.scss
+++ b/src/components/Overlay/Overlay.scss
@@ -24,7 +24,7 @@
   }
 
   &--closing {
-    animation: slow-out 0.5s;
+    animation: slow-out 0.5s forwards;
 
     @keyframes slow-out {
       0% {


### PR DESCRIPTION
Fixes the flickering effect after the overlay is hidden:
![animation](https://user-images.githubusercontent.com/18576413/97159120-0e1f0280-1783-11eb-831a-d369776cdc58.gif)
