### PR TITLE
fix(badge): make badge a span and not a link

### DIFF
--- a/src/components/Badge/Badge.test.tsx
+++ b/src/components/Badge/Badge.test.tsx
@@ -4,9 +4,14 @@ import { shallow } from 'enzyme';
 import { Badge } from './Badge';
 
 describe('Badge', () => {
-  it('supports preeet themes', () => {
-    const component = shallow(<Badge theme='fall-essential'>Fall Essential</Badge>);
-    expect(component.text()).toEqual('Fall Essential');
+  it('supports custom children', () => {
+    const component = shallow(<Badge>Custom Text - 1</Badge>);
+    expect(component.html()).toEqual('<span class="Badge">Custom Text - 1</span>');
+  });
+
+  it('supports custom themes and children', () => {
+    const component = shallow(<Badge theme='trending'>Custom Text - 2</Badge>);
+    expect(component.html()).toEqual('<span class="Badge Badge--trending">Custom Text - 2</span>');
   });
 
   it('allows for arbitrary children', () => {

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -10,7 +10,7 @@ export type BadgeProps = React.AnchorHTMLAttributes<HTMLAnchorElement> & {
 };
 
 export const Badge: React.FC<BadgeProps> = ({ className, theme, children, ...rest }) => (
-  <a className={classNames('Badge', theme && `Badge--${theme}`, className)} {...rest}>
+  <span className={classNames('Badge', theme && `Badge--${theme}`, className)} {...rest}>
     {children}
-  </a>
+  </span>
 );


### PR DESCRIPTION
we don't always want the badge to be a link, we don't use it as that at all (for the moment) and we can wrap it within a <a/> when it's needed;

but, that being used so, created this:
![image](https://user-images.githubusercontent.com/43396056/97539728-25e8c780-19cb-11eb-9d6f-e2a6f7036f1a.png)
