### PR TITLE
feat(breadcrumb): same link divider on mobile as on desktop

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumb/Breadcrumb.scss
+++ b/src/components/Breadcrumbs/Breadcrumb/Breadcrumb.scss
@@ -10,17 +10,13 @@
   // Separators
   &::after {
     display: block;
-    content: '\2022';
+    content: ' ';
     position: absolute;
     top: 50%;
     right: space(1);
     transform: translateY(-50%) rotate(25deg);
-
-    @include breakpoint('sm') {
-      border-right: 1px solid color(fog);
-      content: ' ';
-      height: 75%;
-    }
+    border-right: 1px solid color(fog);
+    height: 75%;
   }
 
   &:last-child {


### PR DESCRIPTION
Make mobile Breadcrumbs look like the desktop ones

Mobile:

![Screenshot 2021-02-23 at 12 49 47](https://user-images.githubusercontent.com/20396500/108833555-ac0dc700-75d5-11eb-80b1-3e5df961ab39.png)


ECOM-793