### PR TITLE
fix(input): onChange type

### DIFF
--- a/src/components/Field/Field.tsx
+++ b/src/components/Field/Field.tsx
@@ -7,7 +7,7 @@ import { Select, SelectProps } from '../Select';
 import './Field.scss';
 
 export type FieldProps = (InputProps | SelectProps) &
-  React.InputHTMLAttributes<HTMLInputElement> & {
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'> & {
     children?: JSX.Element;
   };
 

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -35,9 +35,9 @@ export const SearchInput: React.FC<SearchInputProps> = ({
   }, [onClear]);
 
   const handleChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      onChange && onChange(event);
-      setValue(event.currentTarget.value);
+    (value: string) => {
+      onChange?.(value);
+      setValue(value);
     },
     [onChange, setValue]
   );

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -7,13 +7,15 @@ export type InputProps = {
   error?: boolean | string;
   focus?: boolean;
   label?: string;
+  onChange?: (value: string) => void;
 };
 
-export type TextInputProps = InputProps & React.InputHTMLAttributes<HTMLInputElement>;
+export type TextInputProps = InputProps &
+  Omit<React.InputHTMLAttributes<HTMLInputElement>, 'onChange'>;
 
 export const TextInput = React.forwardRef(
   (
-    { className, disabled, error, focus, placeholder, label, ...rest }: TextInputProps,
+    { className, disabled, error, focus, placeholder, label, onChange, ...rest }: TextInputProps,
     ref: React.Ref<HTMLInputElement>
   ) => {
     return (
@@ -27,6 +29,7 @@ export const TextInput = React.forwardRef(
         placeholder={placeholder}
         aria-label={label || placeholder}
         ref={ref}
+        onChange={event => onChange?.(event.target.value)}
         {...rest}
       />
     );

--- a/src/components/Textarea/Textarea.tsx
+++ b/src/components/Textarea/Textarea.tsx
@@ -3,11 +3,12 @@ import classNames from 'classnames';
 import { InputProps } from '../TextInput';
 import './Textarea.scss';
 
-export type TextareaProps = InputProps & React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+export type TextareaProps = InputProps &
+  Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'onChange'>;
 
 export const Textarea = React.forwardRef(
   (
-    { className, disabled, error, focus, placeholder, label, ...rest }: TextareaProps,
+    { className, disabled, error, focus, placeholder, label, onChange, ...rest }: TextareaProps,
     ref: React.Ref<HTMLTextAreaElement>
   ) => {
     return (
@@ -21,6 +22,7 @@ export const Textarea = React.forwardRef(
         placeholder={placeholder}
         aria-label={label || placeholder}
         ref={ref}
+        onChange={event => onChange?.(event.target.value)}
         {...rest}
       />
     );


### PR DESCRIPTION
Make the onChange type consistent across Input, Textarea and Select.

BREAKING CHANGE: The argument of onChange is the new value instead of the change event in Input and
Textarea