### PR TITLE
feat(popover): make zIndex configurable

### DIFF
--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -12,7 +12,6 @@
     position: absolute;
     background-color: color(snow);
     border: $border-width solid color(elephant);
-    z-index: 1;
 
     // Fills space of offset so hover works without issue
     &:before {
@@ -131,7 +130,6 @@
   &__caret {
     width: 100%;
     position: absolute;
-    z-index: 2;
 
     &:after,
     &:before {

--- a/src/components/Popover/Popover.scss
+++ b/src/components/Popover/Popover.scss
@@ -12,6 +12,7 @@
     position: absolute;
     background-color: color(snow);
     border: $border-width solid color(elephant);
+    z-index: 1;
 
     // Fills space of offset so hover works without issue
     &:before {
@@ -130,6 +131,7 @@
   &__caret {
     width: 100%;
     position: absolute;
+    z-index: 2;
 
     &:after,
     &:before {

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -18,7 +18,7 @@ export const Popover: React.FC<PopoverProps> = ({
   content,
   open = false,
   anchor = 'topLeft',
-  zIndex = 1,
+  zIndex,
   ...rest
 }) => {
   const [isOpen, setOpen] = useState(open);
@@ -49,7 +49,10 @@ export const Popover: React.FC<PopoverProps> = ({
       <span className='Popover__trigger'>
         {isOpen && (
           <>
-            <div className='Popover__caret' style={{ zIndex: zIndex + 1 }} />
+            <div
+              className='Popover__caret'
+              style={{ zIndex: zIndex != null ? zIndex + 1 : undefined }}
+            />
             <div className='Popover__content' style={{ zIndex }}>
               {content}
             </div>

--- a/src/components/Popover/Popover.tsx
+++ b/src/components/Popover/Popover.tsx
@@ -7,6 +7,7 @@ export type PopoverProps = React.HTMLAttributes<HTMLDivElement> & {
   children: JSX.Element;
   open?: boolean;
   anchor?: 'topLeft' | 'topCenter' | 'topRight' | 'bottomLeft' | 'bottomCenter' | 'bottomRight';
+  zIndex?: number;
 };
 
 export const POPOVER_MOUSEOUT_DELAY_MS = 200;
@@ -17,6 +18,7 @@ export const Popover: React.FC<PopoverProps> = ({
   content,
   open = false,
   anchor = 'topLeft',
+  zIndex = 1,
   ...rest
 }) => {
   const [isOpen, setOpen] = useState(open);
@@ -47,8 +49,10 @@ export const Popover: React.FC<PopoverProps> = ({
       <span className='Popover__trigger'>
         {isOpen && (
           <>
-            <div className='Popover__caret' />
-            <div className='Popover__content'>{content}</div>
+            <div className='Popover__caret' style={{ zIndex: zIndex + 1 }} />
+            <div className='Popover__content' style={{ zIndex }}>
+              {content}
+            </div>
           </>
         )}
         {children}


### PR DESCRIPTION
1 is usually a good z-index for the popover content, however in some cases (e.g. in modals) we need a larger z-index.
We can overwrite it from scss but that's not always the cleanest solution, it's a good alternative to pass in the `zIndex` in props.