### PR TITLE
feat(Select): autoSelect

### DIFF
--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -16,6 +16,7 @@ export type SelectProps = Omit<
   'defaultValue' | 'value' | 'onChange'
 > & {
   allowAutoFill?: boolean;
+  autoSelect?: boolean;
   defaultValue?: string | undefined;
   disabled?: boolean;
   dropDirection?: 'down' | 'up';
@@ -32,6 +33,7 @@ export type SelectProps = Omit<
 
 export const Select: React.FC<SelectProps> = ({
   allowAutoFill = false,
+  autoSelect = true,
   className,
   defaultValue,
   disabled,
@@ -51,10 +53,13 @@ export const Select: React.FC<SelectProps> = ({
 
   const handleSelect = useCallback(
     (option: SelectableOption) => {
-      dispatch({ type: 'SELECT', payload: { value: option.value } });
-      onChange && onChange(option.value);
+      dispatch({
+        type: 'SELECT',
+        payload: { value: autoSelect ? option.value : value ?? option.value }
+      });
+      onChange?.(option.value);
     },
-    [dispatch, onChange]
+    [autoSelect, value, dispatch, onChange]
   );
 
   const handleFocus = useCallback(


### PR DESCRIPTION
Adds `autoSelect` to props.
If it's `true`, selecting a value will update the selection automatically, even if the `value` passed from `props` doesn't change.
If it's `false`, selecting a value will not update the selection, the user has to make sure the `value` is appropriately updated on `onChange`.
If no `value` is passed in from props, the component will be _uncontrolled_, meaning that it will keep it's internal state and update it accordingly when selecting a value.

Note: We can usually use the default `autoSelect: true` option. However, there are cases when the user is required to confirm the change. One example is switching rule versions in facade when the current draft is dirty.