### PR TITLE
fix(searchinput): clean up props

### DIFF
--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -8,11 +8,7 @@ export default { title: 'Components/SearchInput' };
 
 export const Default = () => (
   <States<SearchInputProps> states={[{}, { value: 'prada' }, { autoFocus: true }]}>
-    <SearchInput
-      placeholder='Search'
-      onChange={action('onChange')}
-      onChangeValue={action('onChangeValue')}
-    />
+    <SearchInput placeholder='Search' onChange={action('onChange')} />
   </States>
 );
 
@@ -34,7 +30,7 @@ export const DropdownExample = () => {
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column' }}>
-      <SearchInput placeholder='Search' onChangeValue={setQuery} value={query} autoFocus />
+      <SearchInput placeholder='Search' onChange={setQuery} value={query} autoFocus />
 
       {query && (
         <Text style={{ border: '1px solid gray', marginTop: '-1px', padding: '1rem' }}>

--- a/src/components/SearchInput/SearchInput.test.tsx
+++ b/src/components/SearchInput/SearchInput.test.tsx
@@ -14,4 +14,18 @@ describe('SearchInput', () => {
 
     expect(screen.getByRole('textbox')).toHaveValue('');
   });
+
+  it('calls onChange when typing', async () => {
+    const onChange = jest.fn();
+
+    render(<SearchInput value='' onChange={onChange} />);
+
+    await userEvent.type(screen.getByRole('textbox'), 'Greetings');
+
+    expect(onChange).toHaveBeenCalledWith('Greetings');
+
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(onChange).toHaveBeenCalledWith('');
+  });
 });

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -9,7 +9,6 @@ import './SearchInput.scss';
 export type SearchInputProps = TextInputProps & {
   value?: string;
   onClear?(): void;
-  onChangeValue?(value: string): void;
 };
 
 const DEFAULT_INPUT_VALUE = '';
@@ -17,7 +16,6 @@ const DEFAULT_INPUT_VALUE = '';
 export const SearchInput: React.FC<SearchInputProps> = ({
   className,
   onChange,
-  onChangeValue,
   onClear,
   value = DEFAULT_INPUT_VALUE,
   ...rest
@@ -26,13 +24,12 @@ export const SearchInput: React.FC<SearchInputProps> = ({
 
   const [controlledValue, setValue] = useState(value);
 
-  const handleClick = useCallback(() => {
+  const handleClear = useCallback(() => {
     setValue(DEFAULT_INPUT_VALUE);
-    onClear && onClear();
-    if (ref.current) {
-      ref.current.focus();
-    }
-  }, [onClear]);
+    onChange?.(DEFAULT_INPUT_VALUE);
+    onClear?.();
+    ref.current?.focus();
+  }, [onClear, onChange]);
 
   const handleChange = useCallback(
     (value: string) => {
@@ -43,10 +40,6 @@ export const SearchInput: React.FC<SearchInputProps> = ({
   );
 
   useEffect(() => setValue(value), [value]);
-
-  useEffect(() => {
-    onChangeValue && onChangeValue(controlledValue);
-  }, [controlledValue, onChangeValue]);
 
   return (
     <div className={classNames('SearchInput', className)}>
@@ -63,7 +56,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
       />
 
       {controlledValue && (
-        <Clickable className='SearchInput__clear' onClick={handleClick} type='reset'>
+        <Clickable className='SearchInput__clear' onClick={handleClear} type='reset'>
           <ExitIcon />
         </Clickable>
       )}


### PR DESCRIPTION
Removes the 'onChangeValue' callback, 'onChange' can be used instead.
Also removes the `useEffect` that called `onChangeValue`.
Not confirmed, but this can be the source of a UI glitch that happens on the search bar intermittently.

ISSUES WORKED ON: ECOM-2215

BREAKING CHANGE: removed 'onChangeValue'