### PR TITLE
feat(tabs): allow controlling the selected tab

### DIFF
--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import classNames from 'classnames';
 import { Tab, TabList, TabPanels } from '.';
 import './Tabs.scss';
@@ -6,21 +6,28 @@ import './Tabs.scss';
 export type TabsProps = React.HTMLAttributes<HTMLDivElement> & {
   tabs: Tab[];
   onTabClicked?: (tabName: string) => void;
+  defaultActiveTab?: string;
   activeTab?: string;
 };
 
 export const Tabs: React.FC<TabsProps> = ({
   tabs,
   onTabClicked,
+  defaultActiveTab,
   activeTab,
   className,
   ...rest
 }) => {
-  const [activePanel, setActivePanel] = useState(activeTab || tabs[0].name);
+  const [activePanel, setActivePanel] = useState(activeTab || defaultActiveTab || tabs[0].name);
+
   const handleTabClick = (tabName: string) => {
-    setActivePanel(tabName);
+    if (!activeTab) setActivePanel(tabName);
     if (onTabClicked) onTabClicked(tabName);
   };
+
+  useEffect(() => {
+    if (activeTab) setActivePanel(activeTab);
+  }, [activeTab]);
 
   return (
     <div className={classNames('Tabs', className)} {...rest}>


### PR DESCRIPTION
Allows controlling the selected tab by the user of the component.

BREAKING CHANGE: `activeTab` now controls the component, for uncontrolled behavior, use `defaultActiveTab` instead.