### PR TITLE
feat(search): add noBorders prop

### DIFF
--- a/src/components/SearchInput/SearchInput.scss
+++ b/src/components/SearchInput/SearchInput.scss
@@ -19,8 +19,12 @@
     color: color(cement);
   }
 
-  &__input--round-borders { 
+  &__input--round-borders {
     border-radius: 2.5rem;
+  }
+
+  &__input--no-borders {
+    border: none;
   }
 
   &__icon {

--- a/src/components/SearchInput/SearchInput.stories.tsx
+++ b/src/components/SearchInput/SearchInput.stories.tsx
@@ -18,6 +18,12 @@ export const RoundedBorders = () => (
   </States>
 );
 
+export const NoBorders = () => (
+  <States<SearchInputProps> states={[{}, { value: 'prada' }, { autoFocus: true }]}>
+    <SearchInput placeholder='Search' noBorders onChange={action('onChange')} />
+  </States>
+);
+
 export const DropdownExample = () => {
   const [query, setQuery] = useState('');
 

--- a/src/components/SearchInput/SearchInput.tsx
+++ b/src/components/SearchInput/SearchInput.tsx
@@ -10,6 +10,7 @@ export type SearchInputProps = TextInputProps & {
   value?: string;
   onClear?(): void;
   roundBorders?: boolean;
+  noBorders?: boolean;
 };
 
 const DEFAULT_INPUT_VALUE = '';
@@ -19,6 +20,7 @@ export const SearchInput: React.FC<SearchInputProps> = ({
   onChange,
   onClear,
   roundBorders = false,
+  noBorders = false,
   value = DEFAULT_INPUT_VALUE,
   ...rest
 }) => {
@@ -51,7 +53,8 @@ export const SearchInput: React.FC<SearchInputProps> = ({
 
       <TextInput
         className={classNames('SearchInput__input', {
-          'SearchInput__input--round-borders': roundBorders
+          'SearchInput__input--round-borders': roundBorders,
+          'SearchInput__input--no-borders': noBorders
         })}
         onChange={handleChange}
         value={controlledValue}


### PR DESCRIPTION
new Global header refresh suggests that we remove the border on SearchInput. 
Adding that as a prop here. 
![no-borders](https://github.com/user-attachments/assets/af5ee3b1-eaf0-4abd-add4-965035b7e953)
![Screenshot 2024-07-24 at 11 49 33 AM](https://github.com/user-attachments/assets/13fbef11-5337-44da-bf4f-356dbc90f8b6)
